### PR TITLE
add manifest entry for HACS support

### DIFF
--- a/custom_components/stadtreinigung_hamburg/manifest.json
+++ b/custom_components/stadtreinigung_hamburg/manifest.json
@@ -8,4 +8,5 @@
         "stadtreinigung-hamburg==0.1.2"
     ],
     "config_flow": true
+    "homeassistant": "0.97.0"
   }

--- a/custom_components/stadtreinigung_hamburg/manifest.json
+++ b/custom_components/stadtreinigung_hamburg/manifest.json
@@ -7,6 +7,6 @@
     "requirements": [
         "stadtreinigung-hamburg==0.1.2"
     ],
-    "config_flow": true
+    "config_flow": true,
     "homeassistant": "0.97.0"
   }


### PR DESCRIPTION
If I try to install the plugin via HACS there is the following error:
```
Unsupported Home Assistant version
You have version '0.98.2' of Home Assistant, but version 'v0.1.1' of 'Stadtreinigung Hamburg' require version 'None' of Home Assistant, installation and upgrades are disabled for this integration untill you upgrade Home Assistant.
```
I guess the "homeassistant" entry will solve this.
I've chosen `0.97.0` because the current HACS version only works for homeassistant >= 0.97.0