### PR TITLE
Update to use async_forward_entry_setups and async_unload_platforms

### DIFF
--- a/custom_components/hass_stadtreinigung_hamburg/__init__.py
+++ b/custom_components/hass_stadtreinigung_hamburg/__init__.py
@@ -12,13 +12,11 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Stadtreinigung Hamburg as config entry."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
-    )
+    await hass.config_entries.async_forward_entry_setups(config_entry, ["sensor"])
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
+    await hass.config_entries.async_unload_platforms(config_entry, ["sensor"])
     return True


### PR DESCRIPTION
This PR updates the stadtreinigung_hamburg custom integration to replace deprecated methods with their newer counterparts, addressing deprecation warnings and ensuring compatibility with future versions of Home Assistant (specifically Core 2025.6 and beyond).

Changes made:
Replace deprecated method async_forward_entry_setup with async_forward_entry_setups
Replace deprecated method async_forward_entry_unload with async_unload_platforms

Addresses issue #19