### PR TITLE
Replace DEVICE_CLASS_TIMESTAMP with SensorDeviceClass.TIMESTAMP

### DIFF
--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -1,13 +1,12 @@
 import voluptuous as vol
-from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorDeviceClass
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle, slugify
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, DEVICE_CLASS_TIMESTAMP
+from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import Entity
 import logging
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from homeassistant.core import HomeAssistant
 from typing import Optional
 
@@ -99,7 +98,7 @@ class StadtreinigungHamburgSensor(Entity):
     @property
     def device_class(self) -> Optional[str]:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_TIMESTAMP
+        return SensorDeviceClass.TIMESTAMP
 
     @property
     def extra_state_attributes(self):


### PR DESCRIPTION
This PR updates the stadtreinigung_hamburg custom integration to replace the deprecated DEVICE_CLASS_TIMESTAMP with SensorDeviceClass.TIMESTAMP. This change addresses deprecation warnings and ensures future compatibility with Home Assistant Core 2025.1.

This fixes issue #18