### PR TITLE
Implement `DataUpdateCoordinator`, device registry

### DIFF
--- a/custom_components/hass_stadtreinigung_hamburg/__init__.py
+++ b/custom_components/hass_stadtreinigung_hamburg/__init__.py
@@ -1,11 +1,19 @@
 """The Stadtreinigung Hamburg integration"""
 
+from datetime import timedelta
+import logging
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import Platform, CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from stadtreinigung_hamburg.StadtreinigungHamburg import StadtreinigungHamburg
+
+_LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "stadtreinigung_hamburg"
 PLATFORMS = [Platform.SENSOR]
+UPDATE_INTERVAL = timedelta(hours=1)
 
 
 async def async_setup(hass, config):
@@ -15,10 +23,60 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Stadtreinigung Hamburg as config entry."""
+    
+    # Create coordinator for this config entry
+    coordinator = StadtreinigungHamburgCoordinator(
+        hass,
+        config_entry.data[CONF_NAME],
+        config_entry.data["street"],
+        config_entry.data["number"],
+    )
+    
+    # Fetch initial data
+    await coordinator.async_config_entry_first_refresh()
+    
+    # Store coordinator
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][config_entry.entry_id] = coordinator
+    
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+    
+    if unload_ok:
+        hass.data[DOMAIN].pop(config_entry.entry_id)
+    
+    return unload_ok
+
+
+class StadtreinigungHamburgCoordinator(DataUpdateCoordinator):
+    """Coordinator to manage data fetching for Stadtreinigung Hamburg."""
+    
+    def __init__(self, hass: HomeAssistant, name: str, street: str, number: str):
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"Stadtreinigung Hamburg {name}",
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.street = street
+        self.number = number
+        self.location_name = name
+    
+    async def _async_update_data(self):
+        """Fetch data from API."""
+        try:
+            srh = StadtreinigungHamburg()
+            data = await self.hass.async_add_executor_job(
+                srh.get_garbage_collections,
+                self.street,
+                self.number,
+            )
+            return data
+        except Exception as err:
+            raise UpdateFailed(f"Error fetching data: {err}") from err

--- a/custom_components/hass_stadtreinigung_hamburg/__init__.py
+++ b/custom_components/hass_stadtreinigung_hamburg/__init__.py
@@ -1,10 +1,10 @@
 """The Stadtreinigung Hamburg integration"""
 
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform, CONF_NAME
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from stadtreinigung_hamburg.StadtreinigungHamburg import StadtreinigungHamburg
@@ -23,7 +23,7 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Stadtreinigung Hamburg as config entry."""
-    
+
     # Create coordinator for this config entry
     coordinator = StadtreinigungHamburgCoordinator(
         hass,
@@ -31,31 +31,33 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         config_entry.data["street"],
         config_entry.data["number"],
     )
-    
+
     # Fetch initial data
     await coordinator.async_config_entry_first_refresh()
-    
+
     # Store coordinator
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = coordinator
-    
+
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
-    
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, PLATFORMS
+    )
+
     if unload_ok:
         hass.data[DOMAIN].pop(config_entry.entry_id)
-    
+
     return unload_ok
 
 
 class StadtreinigungHamburgCoordinator(DataUpdateCoordinator):
     """Coordinator to manage data fetching for Stadtreinigung Hamburg."""
-    
+
     def __init__(self, hass: HomeAssistant, name: str, street: str, number: str):
         """Initialize the coordinator."""
         super().__init__(
@@ -67,7 +69,7 @@ class StadtreinigungHamburgCoordinator(DataUpdateCoordinator):
         self.street = street
         self.number = number
         self.location_name = name
-    
+
     async def _async_update_data(self):
         """Fetch data from API."""
         try:

--- a/custom_components/hass_stadtreinigung_hamburg/__init__.py
+++ b/custom_components/hass_stadtreinigung_hamburg/__init__.py
@@ -16,7 +16,7 @@ PLATFORMS = [Platform.SENSOR]
 UPDATE_INTERVAL = timedelta(hours=1)
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Do not allow config via configuration.yaml"""
     return True
 
@@ -70,7 +70,7 @@ class StadtreinigungHamburgCoordinator(DataUpdateCoordinator):
         self.number = number
         self.location_name = name
 
-    async def _async_update_data(self):
+    async def _async_update_data(self) -> list:
         """Fetch data from API."""
         try:
             srh = StadtreinigungHamburg()

--- a/custom_components/hass_stadtreinigung_hamburg/__init__.py
+++ b/custom_components/hass_stadtreinigung_hamburg/__init__.py
@@ -1,8 +1,11 @@
 """The Stadtreinigung Hamburg integration"""
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 DOMAIN = "stadtreinigung_hamburg"
+PLATFORMS = [Platform.SENSOR]
 
 
 async def async_setup(hass, config):
@@ -12,11 +15,10 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up Stadtreinigung Hamburg as config entry."""
-    await hass.config_entries.async_forward_entry_setups(config_entry, ["sensor"])
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.config_entries.async_unload_platforms(config_entry, ["sensor"])
-    return True
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)

--- a/custom_components/hass_stadtreinigung_hamburg/config_flow.py
+++ b/custom_components/hass_stadtreinigung_hamburg/config_flow.py
@@ -13,7 +13,7 @@ DOMAIN = "stadtreinigung_hamburg"
 
 
 @callback
-def stadtreinigung_hamburg_names(hass: HomeAssistant):
+def stadtreinigung_hamburg_names(hass: HomeAssistant) -> set[str]:
     """Return configurations of Stadtreinigung Hamburg component."""
     return set(
         (slugify(entry.data[CONF_NAME]))

--- a/custom_components/hass_stadtreinigung_hamburg/config_flow.py
+++ b/custom_components/hass_stadtreinigung_hamburg/config_flow.py
@@ -1,10 +1,13 @@
-from homeassistant import config_entries
 import voluptuous as vol
-from homeassistant.util import slugify
+from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-
-from stadtreinigung_hamburg.StadtreinigungHamburg import *
+from homeassistant.util import slugify
+from stadtreinigung_hamburg.StadtreinigungHamburg import (
+    StadtreinigungHamburg,
+    StreetNotFoundException,
+    StreetNumberNotFoundException,
+)
 
 DOMAIN = "stadtreinigung_hamburg"
 
@@ -18,18 +21,16 @@ def stadtreinigung_hamburg_names(hass: HomeAssistant):
     )
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class StadtreinigungHamburgConfigFlow(config_entries.ConfigFlow):
+class StadtreinigungHamburgConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize."""
         self._street = None
         self._number = None
         self._errors = {}
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> config_entries.ConfigFlowResult:
         self._errors = {}
 
         if user_input is not None:

--- a/custom_components/hass_stadtreinigung_hamburg/manifest.json
+++ b/custom_components/hass_stadtreinigung_hamburg/manifest.json
@@ -11,5 +11,5 @@
         "lxml_html_clean"
     ],
     "config_flow": true,
-    "version": "1.1.2"
+    "version": "1.1.3"
 }

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -44,7 +44,12 @@ sensors = [
 ]
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: dict,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: dict | None = None,
+) -> None:
     """Old way of setting up components.
 
     Can only be called when a user accidentally mentions stadtreinigung_hamburg in the
@@ -113,7 +118,7 @@ class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
         return None
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict:
         """Return the state attributes."""
         # Coordinator automatically handles update timing
         return {}

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -1,6 +1,5 @@
 import logging
-from datetime import datetime, timedelta
-from typing import Literal, Optional
+from typing import Optional
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -12,12 +11,11 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.util import Throttle, slugify
-from stadtreinigung_hamburg.StadtreinigungHamburg import StadtreinigungHamburg
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
-
-MIN_TIME_BETWEEN_UPDATES = timedelta(hours=1)
 
 CONF_STREET = "street"
 CONF_NUMBER = "number"
@@ -55,128 +53,59 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, config_entry: ConfigEntry, config_entries
-) -> bool:
-    """Add a weather entity from map location."""
-    config = config_entry.data
-    name = slugify(config[CONF_NAME])
-
-    data = StadtreinigungHamburgData(
-        config[CONF_NAME], config["street"], config["number"]
-    )
-
-    entries = []
-    for sensor in sensors:
-        entity = StadtreinigungHamburgSensor(sensor, data, name)
-        entries.append(entity)
-
-    config_entries(entries, True)
-    return True
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors from a config entry."""
+    from . import DOMAIN
+    
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    
+    entities = []
+    for sensor_type in sensors:
+        entities.append(StadtreinigungHamburgSensor(coordinator, sensor_type))
+    
+    async_add_entities(entities)
 
 
-class StadtreinigungHamburgSensor(SensorEntity):
-    def __init__(self, container, data, location_name):
+class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a Stadtreinigung Hamburg sensor."""
+    
+    def __init__(self, coordinator, container: str):
+        """Initialize the sensor."""
+        super().__init__(coordinator)
         self.container = container
-        self.data = data
-        self._location_name = location_name
-        self.data = data
-        self._state = None
-        self._last_update = None
-        self._uuid = None
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return self.container
-
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        return self._state
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement."""
-        return ""
-
-    @property
-    def device_class(self) -> Optional[str]:
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return SensorDeviceClass.TIMESTAMP
-
-    @property
-    def extra_state_attributes(self):
-        """Return the state attributes."""
-        return {
-            ATTR_LAST_UPDATE: self._last_update,
-        }
-
-    @property
-    def unique_id(self) -> str:
+        self._attr_name = container
+        self._attr_icon = "mdi:recycle"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        
         # Home Assistant automatically generates entity_id from unique_id and name.
         # Manual entity_id assignment is deprecated and can cause issues with entity registry.
-        return f"stadtreinigung_hamburg_{self._location_name}_{self.container}"
+        self._attr_unique_id = (
+            f"stadtreinigung_hamburg_{coordinator.location_name}_{container}"
+        )
 
     @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        return "mdi:recycle"
-
-    async def async_update(self) -> None:
-        """Fetch new state data for the sensor.
-        This is the only method that should fetch new data for Home Assistant.
-        """
-        await self.data.async_update(self.hass)
-
-        if not self.data.data:
-            return
-
-        collections = sorted(self.data.data, key=lambda x: x.date)
-
+    def native_value(self) -> Optional[str]:
+        """Return the state of the sensor."""
+        if not self.coordinator.data:
+            return None
+        
+        collections = sorted(self.coordinator.data, key=lambda x: x.date)
+        
         if collections:
             collection = next(
                 (c for c in collections if c.container == self.container), None
             )
-
+            
             if collection:
-                self._state = collection.date.isoformat()
-                self._uuid = collection.uuid
-                self._last_update = self.data.last_update
-
-                _LOGGER.debug(collection)
-            else:
-                self._state = None
-        else:
-            self._state = None
-
-
-class StadtreinigungHamburgData:
-    """Get the latest data and update the states."""
-
-    def __init__(self, name, street, number, use_asid=False, use_hnid=False) -> None:
-        self.name = name
-        self.street = street
-        self.number = number
-        self.use_asid = use_asid
-        self.use_hnid = use_hnid
-        self.last_update = None
-        self.data = None
-
-    @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    async def async_update(self, hass) -> None | Literal[False]:
-        _LOGGER.debug("Updating garbage collection dates")
-
-        try:
-            srh = StadtreinigungHamburg()
-            self.data = await hass.async_add_executor_job(
-                srh.get_garbage_collections,
-                self.street,
-                self.number,
-                self.use_asid,
-                self.use_hnid,
-            )
-            self.last_update = datetime.today().isoformat()
-        except Exception as error:
-            _LOGGER.error("Error occurred while fetching data: %r", error)
-            self.data = None
-            return False
+                return collection.date.isoformat()
+        
+        return None
+    
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        # Coordinator automatically handles update timing
+        return {}

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -9,12 +9,10 @@ from homeassistant.components.sensor import (
     SensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.util import slugify
 
 from . import DOMAIN
 
@@ -61,7 +59,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors from a config entry."""
-    
+
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = []
@@ -87,7 +85,7 @@ class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = (
             f"stadtreinigung_hamburg_{coordinator.location_name}_{container}"
         )
-        
+
         # Group all sensors under a single device
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.location_name)},

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -1,15 +1,18 @@
-import voluptuous as vol
-from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorDeviceClass
-import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle, slugify
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME
-from homeassistant.helpers.entity import Entity
 import logging
 from datetime import datetime, timedelta
-from homeassistant.core import HomeAssistant
-from typing import Optional
+from typing import Literal, Optional
 
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant.components.sensor import (
+    PLATFORM_SCHEMA,
+    SensorDeviceClass,
+    SensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.util import Throttle, slugify
 from stadtreinigung_hamburg.StadtreinigungHamburg import StadtreinigungHamburg
 
 _LOGGER = logging.getLogger(__name__)
@@ -64,17 +67,18 @@ async def async_setup_entry(
 
     entries = []
     for sensor in sensors:
-        entity = StadtreinigungHamburgSensor(sensor, data)
-        entity.entity_id = "sensor.stadtreinigung_hamburg_{}_{}".format(name, sensor)
+        entity = StadtreinigungHamburgSensor(sensor, data, name)
         entries.append(entity)
 
     config_entries(entries, True)
     return True
 
 
-class StadtreinigungHamburgSensor(Entity):
-    def __init__(self, container, data):
+class StadtreinigungHamburgSensor(SensorEntity):
+    def __init__(self, container, data, location_name):
         self.container = container
+        self.data = data
+        self._location_name = location_name
         self.data = data
         self._state = None
         self._last_update = None
@@ -108,19 +112,21 @@ class StadtreinigungHamburgSensor(Entity):
         }
 
     @property
-    def unique_id(self):
-        return "stadtreinigung_hamburg" + self.data.name + self.container
+    def unique_id(self) -> str:
+        # Home Assistant automatically generates entity_id from unique_id and name.
+        # Manual entity_id assignment is deprecated and can cause issues with entity registry.
+        return f"stadtreinigung_hamburg_{self._location_name}_{self.container}"
 
     @property
     def icon(self):
         """Return the icon of the sensor."""
         return "mdi:recycle"
 
-    def update(self):
+    async def async_update(self) -> None:
         """Fetch new state data for the sensor.
         This is the only method that should fetch new data for Home Assistant.
         """
-        self.data.update()
+        await self.data.async_update(self.hass)
 
         if not self.data.data:
             return
@@ -147,7 +153,7 @@ class StadtreinigungHamburgSensor(Entity):
 class StadtreinigungHamburgData:
     """Get the latest data and update the states."""
 
-    def __init__(self, name, street, number, use_asid=False, use_hnid=False):
+    def __init__(self, name, street, number, use_asid=False, use_hnid=False) -> None:
         self.name = name
         self.street = street
         self.number = number
@@ -157,12 +163,17 @@ class StadtreinigungHamburgData:
         self.data = None
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
+    async def async_update(self, hass) -> None | Literal[False]:
         _LOGGER.debug("Updating garbage collection dates")
 
         try:
-            self.data = StadtreinigungHamburg().get_garbage_collections(
-                self.street, self.number, self.use_asid, self.use_hnid
+            srh = StadtreinigungHamburg()
+            self.data = await hass.async_add_executor_job(
+                srh.get_garbage_collections,
+                self.street,
+                self.number,
+                self.use_asid,
+                self.use_hnid,
             )
             self.last_update = datetime.today().isoformat()
         except Exception as error:

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -16,6 +16,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import slugify
 
+from . import DOMAIN
+
 _LOGGER = logging.getLogger(__name__)
 
 CONF_STREET = "street"
@@ -59,8 +61,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors from a config entry."""
-    from . import DOMAIN
-
+    
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = []
@@ -88,7 +89,6 @@ class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
         )
         
         # Group all sensors under a single device
-        from . import DOMAIN
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, coordinator.location_name)},
             name=f"Stadtreinigung Hamburg {coordinator.location_name}",

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,19 +60,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors from a config entry."""
     from . import DOMAIN
-    
+
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+
     entities = []
     for sensor_type in sensors:
         entities.append(StadtreinigungHamburgSensor(coordinator, sensor_type))
-    
+
     async_add_entities(entities)
 
 
 class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Stadtreinigung Hamburg sensor."""
-    
+
     def __init__(self, coordinator, container: str):
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -79,11 +80,20 @@ class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
         self._attr_name = container
         self._attr_icon = "mdi:recycle"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        
+
         # Home Assistant automatically generates entity_id from unique_id and name.
         # Manual entity_id assignment is deprecated and can cause issues with entity registry.
         self._attr_unique_id = (
             f"stadtreinigung_hamburg_{coordinator.location_name}_{container}"
+        )
+        
+        # Group all sensors under a single device
+        from . import DOMAIN
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.location_name)},
+            name=f"Stadtreinigung Hamburg {coordinator.location_name}",
+            manufacturer="Stadtreinigung Hamburg",
+            model="Waste Collection Schedule",
         )
 
     @property
@@ -91,19 +101,19 @@ class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
         """Return the state of the sensor."""
         if not self.coordinator.data:
             return None
-        
+
         collections = sorted(self.coordinator.data, key=lambda x: x.date)
-        
+
         if collections:
             collection = next(
                 (c for c in collections if c.container == self.container), None
             )
-            
+
             if collection:
                 return collection.date.isoformat()
-        
+
         return None
-    
+
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from datetime import datetime
 
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util, slugify
 
 from . import DOMAIN
 from .  import StadtreinigungHamburgCoordinator
@@ -85,11 +86,9 @@ class StadtreinigungHamburgSensor(CoordinatorEntity[StadtreinigungHamburgCoordin
         self._attr_name = container
         self._attr_icon = "mdi:recycle"
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
-
-        # Home Assistant automatically generates entity_id from unique_id and name.
-        # Manual entity_id assignment is deprecated and can cause issues with entity registry.
+        self.entity_id = f"sensor.stadtreinigung_hamburg_{slugify(coordinator.location_name)}_{container}"
         self._attr_unique_id = (
-            f"stadtreinigung_hamburg_{coordinator.location_name}_{container}"
+            f"stadtreinigung_hamburg{coordinator.location_name}{container}"
         )
 
         # Group all sensors under a single device
@@ -101,7 +100,7 @@ class StadtreinigungHamburgSensor(CoordinatorEntity[StadtreinigungHamburgCoordin
         )
 
     @property
-    def native_value(self) -> Optional[str]:
+    def native_value(self) -> datetime | None:
         """Return the state of the sensor."""
         if not self.coordinator.data:
             return None
@@ -114,7 +113,7 @@ class StadtreinigungHamburgSensor(CoordinatorEntity[StadtreinigungHamburgCoordin
             )
 
             if collection:
-                return collection.date.isoformat()
+                return collection.date.replace(tzinfo=dt_util.UTC)
 
         return None
 

--- a/custom_components/hass_stadtreinigung_hamburg/sensor.py
+++ b/custom_components/hass_stadtreinigung_hamburg/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN
+from .  import StadtreinigungHamburgCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,10 +75,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class StadtreinigungHamburgSensor(CoordinatorEntity, SensorEntity):
+class StadtreinigungHamburgSensor(CoordinatorEntity[StadtreinigungHamburgCoordinator], SensorEntity):
     """Representation of a Stadtreinigung Hamburg sensor."""
 
-    def __init__(self, coordinator, container: str):
+    def __init__(self, coordinator: StadtreinigungHamburgCoordinator, container: str) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
         self.container = container


### PR DESCRIPTION
This is based on #34.

Modernizes the integration architecture by implementing `DataUpdateCoordinator` for centralized data fetching and adding device registry support to group the sensors.

### Changes

**DataUpdateCoordinator Pattern**
- Implemented `StadtreinigungHamburgCoordinator` to manage data fetching
- Migrated sensors to `CoordinatorEntity` base class
- Eliminates redundant API calls - single fetch per hour shared across all sensors

**Device Registry Integration**
- Added `device_info` property to group all sensors under a single device to improve UI organization

**Code Quality**
- Added comprehensive type hints including generic `CoordinatorEntity[StadtreinigungHamburgCoordinator]`
- Enhanced manifest.json with `iot_class` and `issue_tracker` fields